### PR TITLE
[ZD#2697213] Fix linking emails containing 'mail' in the domain name

### DIFF
--- a/src/linkify/core/scanner.js
+++ b/src/linkify/core/scanner.js
@@ -102,6 +102,7 @@ let partialProtocolMailtoStates = stateify('mailto', S_START, DOMAIN, DOMAIN);
 domainStates.push.apply(domainStates, partialProtocolFileStates);
 domainStates.push.apply(domainStates, partialProtocolFtpStates);
 domainStates.push.apply(domainStates, partialProtocolHttpStates);
+domainStates.push.apply(domainStates, partialProtocolMailtoStates);
 
 // Protocol states
 let S_PROTOCOL_FILE = partialProtocolFileStates.pop();

--- a/test/spec/linkify-string-test.js
+++ b/test/spec/linkify-string-test.js
@@ -59,6 +59,10 @@ describe('linkify-string', () => {
 			'Super long maps URL https://www.google.ca/maps/@43.472082,-80.5426668,18z?hl=en, a #hash-tag, and an email: test.wut.yo@gmail.co.uk!\n',
 			'Super long maps URL <a href="https://www.google.ca/maps/@43.472082,-80.5426668,18z?hl=en" class="linkified" target="_blank">https://www.google.ca/maps/@43.472082,-80.5426668,18z?hl=en</a>, a #hash-tag, and an email: <a href="mailto:test.wut.yo@gmail.co.uk" class="linkified">test.wut.yo@gmail.co.uk</a>!\n',
 			'Super long maps URL <span href="https://www.google.ca/maps/@43.472082,-80.5426668,18z?hl=en" class="my-linkify-class" target="_parent" rel="nofollow" onclick="javascript:alert(&quot;Hello&quot;);">https://www.google.ca/maps/@43.472082,-8…</span>, a #hash-tag, and an email: <span href="mailto:test.wut.yo@gmail.co.uk?subject=Hello%20from%20Linkify" class="my-linkify-class" target="_parent" rel="nofollow" onclick="javascript:alert(&quot;Hello&quot;);">test.wut.yo@gmail.co.uk</span>!<br>\n',
+		], [
+			'Test email address containing "mail" in the start of the domain name example@mailinator.com',
+			'Test email address containing "mail" in the start of the domain name <a href="mailto:example@mailinator.com" class="linkified">example@mailinator.com</a>',
+			'Test email address containing "mail" in the start of the domain name <span href="mailto:example@mailinator.com?subject=Hello%20from%20Linkify" class="my-linkify-class" target="_parent" rel="nofollow" onclick="javascript:alert(&quot;Hello&quot;);">example@mailinator.com</span>'
 		]
 	];
 

--- a/test/spec/linkify/core/parser-test.js
+++ b/test/spec/linkify/core/parser-test.js
@@ -176,6 +176,10 @@ var tests = [
 		'A link in \'singlequote.club/wat\' extra fluff at the end',
 		[TEXT, URL, TEXT],
 		['A link in \'', 'singlequote.club/wat', '\' extra fluff at the end']
+	], [
+		'Email with mailsomething dot com domain in foo@mailsomething.com',
+		[TEXT, EMAIL],
+		['Email with mailsomething dot com domain in ', 'foo@mailsomething.com']
 	]
 ];
 


### PR DESCRIPTION
@zendesk/lotus-dev 
@zendesk/sustaining 

#### What:
https://support.zendesk.com/agent/tickets/2697213

#### Why: 
The problem was in this dependecy that we are using in the `zendesk_editor` project. I'll update the `package.json` for the editor once this gets merged.

Fixes autolinking email addresses which have a domain name of the type `mail*.com`.
For example `test@test.com` would correctly be autolinked, but `test@MAILtest.com` would fail.
